### PR TITLE
fix exit status

### DIFF
--- a/script/errno
+++ b/script/errno
@@ -69,7 +69,7 @@ if ($ARGV[0] =~ /\A\d+\z/) {
             $found++;
         }
     }
-    exit $found ? 0 : 1;
+    exit($found ? 0 : 1);
 }
 
 # ABSTRACT: List/show errno


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $found ? 0 : 1` parses as `(exit $found) ? 0 : 1`, which is not what was intended.